### PR TITLE
Old RegEx returned null

### DIFF
--- a/lib/mac.js
+++ b/lib/mac.js
@@ -5,7 +5,7 @@ const command = 'ioreg -rc AppleSmartBattery | grep Capacity'
 const canRun = () => shellSync('which ioreg').code === 0
 
 const parse = (output) => {
-  const original = output.match(/"DesignCapacity"=(\d+)/)[1]
+  const original = output.match(/"DesignCapacity"(\s)*=(\s)*(\d+)/)[3]
   const now = output.match(/"Capacity"=(\d+)/)[1]
   return { now: parseInt(now), original: parseInt(original) }
 }

--- a/lib/mac.js
+++ b/lib/mac.js
@@ -5,8 +5,8 @@ const command = 'ioreg -rc AppleSmartBattery | grep Capacity'
 const canRun = () => shellSync('which ioreg').code === 0
 
 const parse = (output) => {
-  const original = output.match(/"DesignCapacity"(\s)*=(\s)*(\d+)/)[3]
-  const now = output.match(/"Capacity"=(\d+)/)[1]
+  const original = output.match(/"DesignCapacity"\s*=\s*(\d+)/)[1]
+  const now = output.match(/"Capacity"\s*=\s*(\d+)/)[1]
   return { now: parseInt(now), original: parseInt(original) }
 }
 


### PR DESCRIPTION
System:

- Mac OS 10.13.6
- Node 8.11.1
- npm 6.4.0

Hi there,

I have received the following error because the RegEx in battery.js did not take spaces into account.

> Cannot read property '1' of null
    at Object.darwin (/Users/.../node_modules/healthi/lib/battery.js:17)
    at execa.shell.then (/Users/.../node_modules/healthi/index.js:20)
